### PR TITLE
Parent/child relationship support

### DIFF
--- a/src/stream2es/es.clj
+++ b/src/stream2es/es.clj
@@ -86,7 +86,7 @@
                {:search_type "scan"
                 :scroll ttl
                 :size size
-                :fields "_source,_routing"}})]
+                :fields "_source,_routing,_parent"}})]
     (json/decode (:body resp) true)))
 
 (defn scan

--- a/src/stream2es/stream/es.clj
+++ b/src/stream2es/stream/es.clj
@@ -59,7 +59,9 @@
           {:_id (:_id hit)
            :_type (:_type hit)}
           (when (get-in hit [:fields :_routing])
-            {:_routing (get-in hit [:fields :_routing])}))))
+            {:_routing (get-in hit [:fields :_routing])})
+          (when (get-in hit [:fields :_parent])
+            {:_parent (get-in hit [:fields :_parent])}))))
 
 (defn make-callback [opts handler]
   (fn []


### PR DESCRIPTION
I've noticed that current version doesn't support parent/child relationships while reindexing from one ES index to another. I think it might be important case, so - here is the patch that fixes that.
